### PR TITLE
Fixed title icon bug in Linux, added .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/files/photo_editor.py
+++ b/files/photo_editor.py
@@ -5,6 +5,7 @@ from .menu import Menu
 from PIL import Image, ImageTk, ImageOps, ImageEnhance, ImageFilter
 from .frame import Frame
 from . import settings
+import os
 
 
 class App(ctk.CTk):
@@ -16,7 +17,10 @@ class App(ctk.CTk):
         # self.attributes('-fullscreen', True)
         self.geometry('1000x600')
         self.title(settings.about['title'])
-        self.iconbitmap(settings.title_ico)
+        if os.name == "nt":
+            self.iconbitmap(settings.title_ico)
+        else:
+            self.iconphoto(True, ImageTk.PhotoImage(Image.open(settings.title_png)))
         self.minsize(800, 500)
 
         self.image = None

--- a/files/settings.py
+++ b/files/settings.py
@@ -9,6 +9,7 @@ assets_dir = BASE_DIR / 'assets'
 
 # Define the paths relative to the assets directory
 title_ico = assets_dir / 'image.ico'
+title_png = assets_dir / 'image.png'
 left_image = assets_dir / 'left.png'
 left_enter_image = assets_dir / 'left-arrow.png'
 right_image = assets_dir / 'right.png'


### PR DESCRIPTION
Hello! Your project is great! But in But iconbitmap is not supported on Linux. So I made a check - if your OS is Windows - `iconbitmap` is installed, and if Linux - `iconphoto`. Now PhotoFly runs without problems not only on Windows, **but also on Linux and probably on macOS.** I also added a `.gitignore` file - thanks to it, the .pycache folders will not be added during commits. Thank you if you accept!

![screenshot](https://github.com/user-attachments/assets/e194af0d-7846-4ae9-8a15-4c260173a535)
